### PR TITLE
[회원 가입] 기존 회원 여부 판단, 검증 후 DB Insert

### DIFF
--- a/back-end/api-server/database/query.ts
+++ b/back-end/api-server/database/query.ts
@@ -1,14 +1,19 @@
 import pool from './connect';
 
-export const selectIntoTable = async (column, table, condition = null) => {
-  let queryLine = `SELECT ${column} FROM ${table} `;
-  queryLine += condition ? `WHERE ${condition}` : ``;
+const connectionQuery = async (queryLine) => {
   const connection = await pool.getConnection(async (conn) => conn);
   const [rows] = await connection.query(queryLine);
   connection.release(); // 커넥션 반환
   return rows;
 };
 
-export const insertIntoTable = async (column, table, condition = null) => {
-  let queryLine = `INSERT INTO ${table} VALUES ()`;
+export const selectTable = async (column, table, condition = null) => {
+  let queryLine = `SELECT ${column} FROM ${table} `;
+  queryLine += condition ? `WHERE ${condition}` : ``;
+  return connectionQuery(queryLine);
+};
+
+export const insertIntoTable = async (table, into, values) => {
+  let queryLine = `INSERT INTO ${table} ${into} VALUES (${values})`;
+  return connectionQuery(queryLine);
 };

--- a/back-end/api-server/database/query.ts
+++ b/back-end/api-server/database/query.ts
@@ -1,6 +1,6 @@
 import pool from './connect';
 
-const selectTable = async (column, table, condition = null) => {
+export const selectIntoTable = async (column, table, condition = null) => {
   let queryLine = `SELECT ${column} FROM ${table} `;
   queryLine += condition ? `WHERE ${condition}` : ``;
   const connection = await pool.getConnection(async (conn) => conn);
@@ -8,4 +8,7 @@ const selectTable = async (column, table, condition = null) => {
   connection.release(); // 커넥션 반환
   return rows;
 };
-export default selectTable;
+
+export const insertIntoTable = async (column, table, condition = null) => {
+  let queryLine = `INSERT INTO ${table} VALUES ()`;
+};

--- a/back-end/api-server/routes/auth.ts
+++ b/back-end/api-server/routes/auth.ts
@@ -1,7 +1,7 @@
 import * as express from 'express';
 import axios from 'axios';
 import 'dotenv/config';
-import { selectIntoTable } from '../database/query';
+import { selectTable } from '../database/query';
 
 import { getGithubUser, getUserInfoFromNaver, setJWT } from '../services/auth';
 
@@ -11,7 +11,7 @@ const AuthRouter = express.Router();
   이미 존재하는 회원인지 확인
 */
 const isOauthIdInDB = (oauthID) => {
-  return selectIntoTable('*', 'USER_INFO', `oauth_id='${oauthID}'`);
+  return selectTable('*', 'USER_INFO', `oauth_id='${oauthID}'`);
 };
 
 const oauthDupCheck = async (id, req, res) => {
@@ -52,7 +52,8 @@ AuthRouter.post('/github/code', async (req, res) => {
     const { access_token } = data;
     const user = await getGithubUser(access_token);
     const isOurUser = await oauthDupCheck(user['login'], req, res); // 일단 중복 안되는 login 으로 해놓음
-    res.status(200).json({ user, isOurUser });
+    const id = user.id;
+    res.status(200).json({ id, isOurUser });
   } catch (error) {
     console.error(error);
     res.sendStatus(400);

--- a/back-end/api-server/routes/auth.ts
+++ b/back-end/api-server/routes/auth.ts
@@ -1,7 +1,7 @@
 import * as express from 'express';
 import axios from 'axios';
 import 'dotenv/config';
-import selectTable from '../database/query';
+import { selectIntoTable } from '../database/query';
 
 import { getGithubUser, getUserInfoFromNaver, setJWT } from '../services/auth';
 
@@ -11,7 +11,7 @@ const AuthRouter = express.Router();
   이미 존재하는 회원인지 확인
 */
 const isOauthIdInDB = (oauthID) => {
-  return selectTable('*', 'USER_INFO', `oauth_id='${oauthID}'`);
+  return selectIntoTable('*', 'USER_INFO', `oauth_id='${oauthID}'`);
 };
 
 const oauthDupCheck = async (id, req, res) => {
@@ -62,18 +62,15 @@ AuthRouter.post('/github/code', async (req, res) => {
 AuthRouter.post('/naver/token', async (req, res) => {
   const { accessToken } = req.body;
   const userInfoFromNaver = await getUserInfoFromNaver(accessToken);
-  const email = userInfoFromNaver['response']['email'];
-  const name = userInfoFromNaver['response']['name'];
   const id = userInfoFromNaver['response']['id'];
-
   const isOurUser = await oauthDupCheck(id, req, res);
-  res.json({ email, name, isOurUser });
+  res.json({ id, isOurUser });
 });
 
 AuthRouter.post('/google/user', async (req, res) => {
   const { email, name } = req.body;
   const isOurUser = await oauthDupCheck(email, req, res);
-  res.json({ email, name, isOurUser });
+  res.json({ email, isOurUser });
 });
 
 export default AuthRouter;

--- a/back-end/api-server/routes/registerDBInsert.ts
+++ b/back-end/api-server/routes/registerDBInsert.ts
@@ -1,10 +1,27 @@
 import * as express from 'express';
-import { selectIntoTable } from '../database/query';
+import { insertIntoTable } from '../database/query';
+
 const RegisterRouter = express.Router();
 
 RegisterRouter.post('/insert', (req, res, next) => {
   //db insert 로직 필요
-  const nickName = req.body;
+  const data = req.body.registerData;
+  const nickName = data.nickname;
+  const message = data.message;
+  const authId = data.oauthInfo;
+  if (
+    insertIntoTable(
+      'USER_INFO',
+      '(nickname, state_message, oauth_id, total_game_number, total_win, total_play_time)',
+      `'${nickName}', '${message}', '${authId}', 0, 0, '00:00:00'`
+    )
+  ) {
+    // DB에 넣는 것이 실패한 경우
+    res.json({ dupCheck: true, dbInsertError: true });
+  } else {
+    res.json({ dupCheck: true, dbInsertError: false });
+  }
 });
 
 export default RegisterRouter;
+//`INSERT INTO ${table} VALUES (${values})`;

--- a/back-end/api-server/routes/registerDBInsert.ts
+++ b/back-end/api-server/routes/registerDBInsert.ts
@@ -1,0 +1,10 @@
+import * as express from 'express';
+import { selectIntoTable } from '../database/query';
+const RegisterRouter = express.Router();
+
+RegisterRouter.post('/insert', (req, res, next) => {
+  //db insert 로직 필요
+  const nickName = req.body;
+});
+
+export default RegisterRouter;

--- a/back-end/api-server/routes/registerDupCheck.ts
+++ b/back-end/api-server/routes/registerDupCheck.ts
@@ -1,10 +1,10 @@
 import * as express from 'express';
-import { selectIntoTable } from '../database/query';
+import { selectTable } from '../database/query';
 const RegisterRouter = express.Router();
 
 RegisterRouter.post('/insert', async (req, res, next) => {
   const nickName = req.body['registerData']['nickname'];
-  const userDupCheckResult = await selectIntoTable(
+  const userDupCheckResult = await selectTable(
     '*',
     'USER_INFO',
     `nickname='${nickName}'`

--- a/back-end/api-server/routes/registerDupCheck.ts
+++ b/back-end/api-server/routes/registerDupCheck.ts
@@ -1,0 +1,17 @@
+import * as express from 'express';
+import { selectIntoTable } from '../database/query';
+const RegisterRouter = express.Router();
+
+RegisterRouter.post('/insert', async (req, res, next) => {
+  const nickName = req.body['registerData']['nickname'];
+  const userDupCheckResult = await selectIntoTable(
+    '*',
+    'USER_INFO',
+    `nickname='${nickName}'`
+  );
+  if (userDupCheckResult?.length) {
+    res.json({ dupCheck: false });
+  } else next();
+});
+
+export default RegisterRouter;

--- a/back-end/api-server/src/index.ts
+++ b/back-end/api-server/src/index.ts
@@ -6,6 +6,8 @@ const logger = require('morgan');
 const axios = require('axios');
 import 'dotenv/config';
 import AuthRouter from '../routes/auth';
+import InsertDbRegister from '../routes/registerDBInsert';
+import checkDupNickRegister from '../routes/registerDupCheck';
 
 class App {
   public application: express.Application;
@@ -26,6 +28,7 @@ app.use(logger('dev'));
 app.use(express.urlencoded({ extended: false }));
 app.use(express.static(path.join(__dirname, 'public')));
 app.use('/auth', AuthRouter);
+app.use('/register', checkDupNickRegister, InsertDbRegister);
 
 app.get('/', (req: express.Request, res: express.Response) => {
   res.send('start');

--- a/front-end/src/components/BasicButton/index.tsx
+++ b/front-end/src/components/BasicButton/index.tsx
@@ -1,7 +1,20 @@
 import './style.scss';
+import { useHistory } from 'react-router-dom';
 
-function BasicButton({ variant = 'contained', label = '' }) {
-  return <button className={`btn__root btn__root--${variant}`}>{label}</button>;
+function BasicButton({ 
+  variant = 'contained', 
+  label = '', 
+  registerData = {},
+  submit
+}: {
+  variant: string, 
+  label: string, 
+  registerData: object,
+  submit: Function,
+}) {
+  const history = useHistory();
+
+  return <button onClick={()=>{submit(registerData, label, history)}} className={`btn__root btn__root--${variant}`}>{label}</button>;
 }
 
 export default BasicButton;

--- a/front-end/src/components/BasicButton/style.scss
+++ b/front-end/src/components/BasicButton/style.scss
@@ -13,4 +13,5 @@
     color: $dark-navy;
     border: 1px solid $dark-navy;
   }
+  cursor: pointer;
 }

--- a/front-end/src/components/BasicInput/index.tsx
+++ b/front-end/src/components/BasicInput/index.tsx
@@ -1,22 +1,44 @@
+import { useCallback, useEffect, useRef } from 'react';
 import './style.scss';
 
 function BasicInput({
   label = '',
   placeholder = '',
   type = 'input',
+  registerData = {}
 }: {
   label: string;
   placeholder: string;
   type: string;
+  registerData: any
 }) {
+  const NICKNAME_MAX = 10;
+  const MESSAGE_MAX = 50;
+
+  const onChangeNickname = useCallback(e=>{
+    if (e.target.value.length > NICKNAME_MAX) {
+      e.target.value = e.target.value.slice(0, -1);
+      alert(`글자수는 ${NICKNAME_MAX}자 제한입니다`) // UX 관점에서 개선 필요
+    }
+    registerData.nickname = e.target.value;
+  },[]);
+
+  const onChangeMessage = useCallback(e=>{
+    if (e.target.value.length > MESSAGE_MAX) {
+      e.target.value = e.target.value.slice(0, -1);
+      alert(`상태메세지는 ${MESSAGE_MAX}자 제한입니다`)
+    }
+    registerData.message = e.target.value;
+  }, []);
+
   return (
     <label className="input__label--root" htmlFor={label}>
       <div className="input__label--text">{label}</div>
       {type === 'input' && (
-        <input id={label} name={label} placeholder={placeholder} />
+        <input id={label} name={label} onChange={onChangeNickname} placeholder={placeholder}/>
       )}
       {type === 'textarea' && (
-        <textarea id={label} name={label} placeholder={placeholder} rows={5} />
+        <textarea id={label} name={label} onChange={onChangeMessage} placeholder={placeholder} rows={5}/>
       )}
     </label>
   );

--- a/front-end/src/pages/RegisterPage/index.tsx
+++ b/front-end/src/pages/RegisterPage/index.tsx
@@ -46,7 +46,6 @@ function RegisterPage() {
   }
   const history = useHistory();
   registerData['oauthInfo'] = history.location.state;
-  
   return (
     <div className="register__root full__page--root">
       <div className="register__card--root">

--- a/front-end/src/pages/RegisterPage/index.tsx
+++ b/front-end/src/pages/RegisterPage/index.tsx
@@ -1,8 +1,52 @@
 import BasicButton from '../../components/BasicButton';
 import BasicInput from '../../components/BasicInput';
+import { useHistory } from 'react-router';
 import './style.scss';
 
+const registerButtonHandler = async(registerData:any, label:string, history:any) => {
+  if (label === '제출') {
+    console.log(registerData);
+    if (!registerData['nickname'].length) {
+      alert('닉네임을 최소한 한글자는 입력해 주세요 !!!')
+      return;
+    }
+    let registerCheck:any = await fetch('/register/insert', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      credentials: 'include',
+      body: JSON.stringify({registerData: registerData})
+    })
+    registerCheck = await registerCheck.json();
+    if (!registerCheck['dupCheck']) {
+      alert('이미 존재하는 닉네임 입니다 !')
+      return ;
+    } else {
+      // 다음 페이지로 넘어가는 로직 필요
+      // 유저의 닉네임 등등 필요함
+    }
+  }
+  else if (label === '취소') {
+    history.replace('/login');
+  }
+}
+
 function RegisterPage() {
+  interface registerDataContent{
+    'nickname': string,
+    'message': string,
+    'oauthInfo': any
+  }
+  const registerData:registerDataContent = {
+    'nickname': '',
+    'message': '',
+    'oauthInfo': {}
+  }
+  const history = useHistory();
+  registerData['oauthInfo'] = history.location.state;
+  
   return (
     <div className="register__root full__page--root">
       <div className="register__card--root">
@@ -11,17 +55,19 @@ function RegisterPage() {
           label={'닉네임'}
           placeholder="닉네임을 입력해주세요."
           type="input"
+          registerData = {registerData}
         />
         <div className="mb--40"></div>
         <BasicInput
           label={'상태메세지'}
           placeholder="상태메세지를 입력해주세요."
           type="textarea"
+          registerData = {registerData}
         />
         <div className="mb--40"></div>
         <div className="register__card--footer">
-          <BasicButton variant="contained" label={'제출'} />
-          <BasicButton variant="outlined" label={'취소'} />
+          <BasicButton variant="contained" label={'제출'} registerData = {registerData} submit = {registerButtonHandler}/>
+          <BasicButton variant="outlined" label={'취소'} registerData = {registerData} submit = {registerButtonHandler}/>
         </div>
       </div>
     </div>

--- a/front-end/src/pages/RegisterPage/index.tsx
+++ b/front-end/src/pages/RegisterPage/index.tsx
@@ -24,6 +24,7 @@ const registerButtonHandler = async(registerData:any, label:string, history:any)
       alert('이미 존재하는 닉네임 입니다 !')
       return ;
     } else {
+      console.log(registerCheck);
       // 다음 페이지로 넘어가는 로직 필요
       // 유저의 닉네임 등등 필요함
     }
@@ -46,6 +47,7 @@ function RegisterPage() {
   }
   const history = useHistory();
   registerData['oauthInfo'] = history.location.state;
+  registerData['oauthInfo'] = registerData['oauthInfo'].id;
   return (
     <div className="register__root full__page--root">
       <div className="register__card--root">

--- a/front-end/src/routes/OauthCallbackRouter/GithubCallback.tsx
+++ b/front-end/src/routes/OauthCallbackRouter/GithubCallback.tsx
@@ -21,11 +21,11 @@ function GithubCallback() {
       return response.json();
     };
     fetchGithubUserData()
-      .then(({ user }) => {
-        if (user.isOurUser) {
-          history.replace('/', { user });
+      .then(({ id, isOurUser }) => {
+        if (isOurUser) {
+          history.replace('/', { id });
         } else {
-          history.replace('/register');
+          history.replace('/register', { id });
         }
       })
       .catch((err) => {

--- a/front-end/src/routes/OauthCallbackRouter/GoogleCallback.tsx
+++ b/front-end/src/routes/OauthCallbackRouter/GoogleCallback.tsx
@@ -24,10 +24,11 @@ function GoogleCallback() {
 
   useEffect(() => {
     loginSuccess(state).then(({ email, isOurUser }) => {
+      const id = email;
       if (isOurUser) {
-        history.replace('/', { email});
+        history.replace('/', { id });
       } else {
-        history.replace('/register', { email } );
+        history.replace('/register', { id } );
       }
     });
   }, [history, state]);

--- a/front-end/src/routes/OauthCallbackRouter/GoogleCallback.tsx
+++ b/front-end/src/routes/OauthCallbackRouter/GoogleCallback.tsx
@@ -23,11 +23,11 @@ function GoogleCallback() {
   };
 
   useEffect(() => {
-    loginSuccess(state).then(({ name, isOurUser }) => {
+    loginSuccess(state).then(({ email, name, isOurUser }) => {
       if (isOurUser) {
-        history.replace('/', { name });
+        history.replace('/', { email, name });
       } else {
-        history.replace('/register');
+        history.replace('/register', { email, name } );
       }
     });
   }, [history, state]);

--- a/front-end/src/routes/OauthCallbackRouter/GoogleCallback.tsx
+++ b/front-end/src/routes/OauthCallbackRouter/GoogleCallback.tsx
@@ -23,11 +23,11 @@ function GoogleCallback() {
   };
 
   useEffect(() => {
-    loginSuccess(state).then(({ email, name, isOurUser }) => {
+    loginSuccess(state).then(({ email, isOurUser }) => {
       if (isOurUser) {
-        history.replace('/', { email, name });
+        history.replace('/', { email});
       } else {
-        history.replace('/register', { email, name } );
+        history.replace('/register', { email } );
       }
     });
   }, [history, state]);

--- a/front-end/src/routes/OauthCallbackRouter/NaverCallback.tsx
+++ b/front-end/src/routes/OauthCallbackRouter/NaverCallback.tsx
@@ -20,13 +20,13 @@ function NaverCallback() {
     };
     const accessToken = location.hash.split('=')[1].split('&')[0];
 
-    fetchNaverUserData(accessToken).then(({ isOurUser }) => {
+    fetchNaverUserData(accessToken).then(({ id, isOurUser }) => {
+      console.log(isOurUser);
       if (isOurUser) {
-        history.replace('/');
+        history.replace('/', {id});
       } else {
-        history.replace('/register');
+        history.replace('/register', {id});
       }
-      // console.log(document.cookie);
     });
   }, [history, location.hash]);
   return <div></div>;


### PR DESCRIPTION
### 작업 개요
<!--
  ex) 고양이가 야옹 소리를 내도록 수정
-->
회원 가입 페이지에서 필요한 로직들 구현 완료

### Github Issue Number
<!--
  ex) BAEMIN-1004
-->
### 작업 분류
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경
<!--
  - [ ] 버그 수정
  - [x] 신규 기능
  - [ ] 프로젝트 구조 변경
-->
### 작업 상세 내용
<!--
  ex) 
  1. 네 발 짐승 클래스에 `크앙` 함수 추가
  2. 고양이 클래스에서 `크앙` 함수에 `미야아옹.wav` 재생시킴
-->
✨ : 기존 회원 여부 판단 - 프론트에서의 register 검증 로직
1. register 화면에서 닉네임 길이, 상태 메세지 길이 확인
2. 제출 버튼 누를 시 서버로 전송하여 중복되는 닉네임인지 먼저 확인
3. 중복되는 닉네임이 아닐 경우 next()로 다음 라우터로 이동

✨ : 기존 회원 여부 판단 - 네이버, 구글, 깃허브

✨ : 새로운 유저 DB Insert 코드 작성
1. 새로운 유저를 DB Insert
2. 시간 등은 초기값으로 0 부여
3. db 코드 리팩토링
4. db insert에 성공시 dbInsertError: true 리턴. 추후 db insert 실패
   예외처리 코드 필요
### 생각해볼 문제
<!--
  ex) 
  1. wav 파일을 매번 입력하기 귀찮겠다.
-->
1. 중복 회원 체크하는 부분에서 굳이 select를 하지 않고 insert 한 후에 예외처리 해도 될 거 같다.
2. 예외처리 할 곳이 많아 보임
3. 타입 스크립트를 쓰는 만큼, 타입 정의를 신경써야할 것으로 보임.
