### PR TITLE
프로필 페이지에서의 자잘한 오류들을 수정함

### DIFF
--- a/front-end/src/components/InfiniteScroll/style.scss
+++ b/front-end/src/components/InfiniteScroll/style.scss
@@ -1,7 +1,7 @@
 @import 'common/styles/base';
 
 .recent__list--scroll {
-  height: 250px;
+  height: 260px;
   overflow-y: scroll;
 
   .recent__list {

--- a/front-end/src/pages/ProfilePage/index.tsx
+++ b/front-end/src/pages/ProfilePage/index.tsx
@@ -85,7 +85,7 @@ export default function Profile() {
         if (res.message === 'done') {
           setEditMode(!editMode);
           await dispatch(updateNickname());
-          socketClient.current.emit('set userName', userState.nickname);
+          socketClient.current.emit('set userName', userState.nickname, userState.id);
           navigate(`/profile/${userState.nickname}`, { replace: true });
         }
       } catch (error) {


### PR DESCRIPTION
### 작업 개요
- 닉네임 변경시 소켓이 터지는 오류 수정
- 인피니티 스크롤이 안불러와지는 현상 수정

### Github Issue Number
#202 

### 작업 분류
- [x] 버그 수정
- [ ] 신규 기능
- [ ] 프로젝트 구조 변경
<!--
  - [ ] 버그 수정
  - [x] 신규 기능
  - [ ] 프로젝트 구조 변경
-->
### 작업 상세 내용
<!--
  ex) 
  1. 네 발 짐승 클래스에 `크앙` 함수 추가
  2. 고양이 클래스에서 `크앙` 함수에 `미야아옹.wav` 재생시킴
-->
### 생각해볼 문제
<!--
  ex) 
  1. wav 파일을 매번 입력하기 귀찮겠다.
-->


` useEffect(() => {
    setPageNum(0);
  }, [nickname]);

useEffect(() => {
    //데이터 fetch
  }, [pageNum]);

종종 pageNum이 그대로 0이여서 nickname이 바뀌어도 setPageNum이 0이니까 아래에 있는 useEffect가 작동되지 않는 일이 있는데 이런 경우에는 어떻게 해야할까요?

1. pageNum의 useEffect에 setPageNum(-1)로 달기
2. nickname의 useEffect에  setPageNum(-1)로 달기
3. 다른 방법 찾아보기
`
